### PR TITLE
fix: don't match EOL for single line pipe

### DIFF
--- a/lua/cmp_nvim_r/init.lua
+++ b/lua/cmp_nvim_r/init.lua
@@ -382,11 +382,11 @@ source.asynccb = function(cid, compl)
 end
 
 local GetPipedObj = function(line, lnum)
-    if string.find(line, "|>%s*$") then
-        return string.match(line, ".-([%w%._]+)%s*|>%s*$")
+    if string.find(line, "|>") then
+        return string.match(line, ".-([%w%._]+)%s*|>")
     end
-    if string.find(line, "%%>%%%s*$") then
-        return string.match(line, ".-([%w%._]+)%s*%%>%%%s*$")
+    if string.find(line, "%%>%%") then
+        return string.match(line, ".-([%w%._]+)%s*%%>%%")
     end
     local l
     l = vim.fn.getline(lnum - 1)


### PR DESCRIPTION
This matches the first piped item on a line, which appears to be the intended behaviour #5