### PR TITLE
feat: follow completion through multiline pipes

### DIFF
--- a/lua/cmp_nvim_r/init.lua
+++ b/lua/cmp_nvim_r/init.lua
@@ -381,20 +381,21 @@ source.asynccb = function(cid, compl)
     cb_cmp(resp)
 end
 
-local GetPipedObj = function(line, lnum)
+local GetPipedObj
+GetPipedObj = function(line, lnum)
+    local l
+    l = vim.fn.getline(lnum - 1)
+    if type(l) == "string" and string.find(l, "|>%s*$") then
+        return GetPipedObj(l, lnum - 1)
+    end
+    if type(l) == "string" and string.find(l, "%%>%%%s*$") then
+        return GetPipedObj(l, lnum - 1)
+    end
     if string.find(line, "|>") then
         return string.match(line, ".-([%w%._]+)%s*|>")
     end
     if string.find(line, "%%>%%") then
         return string.match(line, ".-([%w%._]+)%s*%%>%%")
-    end
-    local l
-    l = vim.fn.getline(lnum - 1)
-    if type(l) == "string" and string.find(l, "|>%s*$") then
-        return string.match(l, ".-([%w%._]+)%s*|>%s*$")
-    end
-    if type(l) == "string" and string.find(l, "%%>%%%s*$") then
-        return string.match(l, ".-([%w%._]+)%s*%%>%%%s*$")
     end
     return nil
 end


### PR DESCRIPTION
This allows completions to follow multi-line pipes as discussed in issue #5 .

I didn't add it as an option here, since a single object is already followed through multiple pipes on a single line, so this is just consistent over line breaks. To make behaviour consistent over single/multiple lines with the option turned off, single line pipelines need to be changed to offer suggestions only when there is a single pipe on the line, or additional pipes are inside of function arguments (and not part of the pipeline), or you are in a function after the first pipe on the line. This seems like more effort than it is worth, but I'm happy to add an option to toggle the changes in this PR.